### PR TITLE
Fix multibyte unicode in stylesheet path bug

### DIFF
--- a/src/extensionData.ts
+++ b/src/extensionData.ts
@@ -9,8 +9,8 @@ export class ExtensionData {
 
 	static getSefPath() {
 		const rawPath = path.join(ExtensionData.extensionPath, 'resources', 'xslt-sef', 'xpath-eval-to-json.sef.json');
-		const escapedSlashPath = rawPath.replace(/(\\)/g, '\\$1');
-		return escapedSlashPath;
+		const uri = vscode.Uri.file( rawPath );
+		return uri.toString();
 	}
 	private static baseUri: string | undefined;
 	private static staticBaseUri: string | undefined;


### PR DESCRIPTION
Fixes a bug (#8) that prevents evaluation of the XPath expression by SaxonJS when the path to the stylesheet has unicode characters that need multi-byte encoding (i.e., basically when the user folder path has these kind of characters).